### PR TITLE
fix: split `cf_exp` calculation into parts to fix output

### DIFF
--- a/d_ratio.py
+++ b/d_ratio.py
@@ -113,10 +113,14 @@ def risk_skew_kurt(log_return):
 def risk_cf_exp_var(log_return, asset_value, confid):
     (mean, st_dev), (skew, kurt) = risk_skew_kurt(log_return)
     quantile = norm.ppf(confid)
-    cf_exp = quantile + (quantile ** 2 - 1) * skew / 6 
-    + (quantile ** 3 - 3 * quantile) * kurt / 24 
-    - (2 * quantile ** 3 - 5 * quantile) * (skew ** 2) / 36
+    
+    part_1 = (quantile ** 2 -1) * skew / 6
+    part_2 = (quantile ** 3 - 3 * quantile) * kurt / 24
+    part_3 = (2 * quantile ** 3 - 5 * quantile) * (skew ** 2) / 36
+    cf_exp = quantile + part_1 + part_2 - part_3
+    
     cf_var = mean + st_dev * cf_exp
     cf_asset_value = asset_value * (1 + cf_var)
+    
     return cf_exp, cf_var, cf_asset_value
 


### PR DESCRIPTION
This fixes an associativity issue in the computation.

After revisiting this project and comparing the output of its implementation with my rust implementation ( Here: https://github.com/MathisWellmann/lfest-rs/blob/35963d8f46c1917fbbfc38e21c67e75838482b8a/src/cornish_fisher.rs#L49), I came across a discrepancy between the output of the rust vs python version. 
It looks like python does associativity differently and the new code which assigns the intermediate computation to variables produces the correct output just like my rust version.
The computation output of `cf_exp` should now be in line with what is expected.